### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ UIGuidedView is a simple control designed for guiding a user through a controlle
 
 ## Installation
 
-1. UIGuidedView can be installed via [Cocoapods](http://cocoapods.org/) by adding `pod 'UIGuidedView'` to your podfile, or you can manually add `UIGuidedView.h/m` and `UIBezierPath+Circle.h/.m` into your project.
+1. UIGuidedView can be installed via [CocoaPods](http://cocoapods.org/) by adding `pod 'UIGuidedView'` to your podfile, or you can manually add `UIGuidedView.h/m` and `UIBezierPath+Circle.h/.m` into your project.
 2. Create a `@property (strong, nonatomic) UIGuidedView *guidedView`, setup its frame, and in your class and set the guided view's dataSource. The only required method to implement is `- (NSInteger)numberOfNodesForGuidedView:(UIGuidedView *)view;`
 
 		//YourViewController.m


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
